### PR TITLE
Whitelist matching correction

### DIFF
--- a/backgrounds/main.js
+++ b/backgrounds/main.js
@@ -63,20 +63,22 @@ function retrieve () { // eslint-disable-line no-unused-vars
 }
 
 function filterRequest (request) {
-  let cancel = false
-  for (let regex of regexes) {
-    if ((mode === '0' && regex.test(request.url)) ||
-      (mode === '1' && !regex.test(request.url))
-    ) {
-      if (debug === '1') {
-        console.log('Canceled request: ' + request.url)
-      }
-      cancel = true
-      break
-    }
-  }
+  let cancel = mode == '1'
+  for (let regex of regexes) {
+    if (mode === '0' && regex.test(request.url)) {
+      cancel = true
+      break
+    }
+    if (mode === '1' && regex.test(request.url)) {
+        cancel = false
+        break
+    }
+  }
 
-  return { cancel: cancel }
+  if (debug === '1' && cancel == true) {
+        console.log('Canceled request: ' + request.url)
+  }
+  return { cancel: cancel }
 }
 
 browser.storage.local.get('simpleBlocker').then((data) => {


### PR DESCRIPTION
Whitelists allows URLs that match a single expression rather than making to match all fixes issue 8 [https://github.com/eryw/firefox-simple-blocker/issues/8](url) which i raised. Same change should be applied to the chrome version