### PR TITLE
Add support for comments

### DIFF
--- a/backgrounds/main.js
+++ b/backgrounds/main.js
@@ -24,7 +24,7 @@ function updateCacheVar (strRegexArray, lmode, ldebug) {
   debug = ldebug
   regexes = []
   for (let r of strRegexArray) {
-    if (r) {
+    if (r && !(r.trim()).startsWith('//')) { // non-empty lines that aren't comments
       try {
         regexes.push(new RegExp(r))
       } catch (e) {


### PR DESCRIPTION
Lines starting with '//'  are considered comments and are skipped. May optionally be preceded by white-space characters.